### PR TITLE
Move `ibc` property init to original location, revert whitespace changes

### DIFF
--- a/photosyst.c
+++ b/photosyst.c
@@ -1946,32 +1946,6 @@ ibprep(struct ibcachent *ibc)
 	FILE	*fp;
 	char	path[128], linebuf[64], speedunit;
 
-    // build all pathnames to obtain the counters
-    // of this port later on
-    snprintf(path, sizeof path,
-             "%s/ports/%d/counters/port_rcv_data",
-             ibc->ibha, ibc->port);
-    ibc->pathrcvb = malloc( strlen(path)+1 );
-    strcpy(ibc->pathrcvb, path);
-
-    snprintf(path, sizeof path,
-             "%s/ports/%d/counters/port_xmit_data",
-             ibc->ibha, ibc->port);
-    ibc->pathsndb = malloc( strlen(path)+1 );
-    strcpy(ibc->pathsndb, path);
-
-    snprintf(path, sizeof path,
-             "%s/ports/%d/counters/port_rcv_packets",
-             ibc->ibha, ibc->port);
-    ibc->pathrcvp = malloc( strlen(path)+1 );
-    strcpy(ibc->pathrcvp, path);
-
-    snprintf(path, sizeof path,
-             "%s/ports/%d/counters/port_xmit_packets",
-             ibc->ibha, ibc->port);
-    ibc->pathsndp = malloc( strlen(path)+1 );
-    strcpy(ibc->pathsndp, path);
-
 	// determine port rate and number of lanes
 	snprintf(path, sizeof path, "%s/ports/%d/rate", ibc->ibha, ibc->port); 
 
@@ -1982,30 +1956,53 @@ ibprep(struct ibcachent *ibc)
 			(void) sscanf(linebuf, "%lld %c%*s (%hdX",
 				&(ibc->rate), &speedunit, &(ibc->lanes));
 
-            // calculate megabits/second
-            switch (speedunit)
-            {
-               case 'M':
-               case 'm':
-                break;
-               case 'G':
-               case 'g':
-                ibc->rate *= 1000;
-                break;
-               case 'T':
-               case 't':
-                ibc->rate *= 1000000;
-                break;
-            }
-        }
-        else
-        {
-            ibc->lanes = 0;
-            ibc->rate = 0;
-        }
+			// calculate megabits/second
+			switch (speedunit)
+			{
+			   case 'M':
+			   case 'm':
+				break;
+			   case 'G':
+			   case 'g':
+				ibc->rate *= 1000;
+				break;
+			   case 'T':
+			   case 't':
+				ibc->rate *= 1000000;
+				break;
+			}
+
+		}
+		else
+		{
+			ibc->lanes = 0;
+			ibc->rate = 0;
+		}
 
 		fclose(fp);
 	}
+
+	// build all pathnames to obtain the counters
+	// of this port later on
+	snprintf(path, sizeof path, "%s/ports/%d/counters/port_rcv_data",
+						    ibc->ibha, ibc->port);
+	ibc->pathrcvb = malloc( strlen(path)+1 );
+	strcpy(ibc->pathrcvb, path);
+
+	snprintf(path, sizeof path, "%s/ports/%d/counters/port_xmit_data",
+						    ibc->ibha, ibc->port);
+	ibc->pathsndb = malloc( strlen(path)+1 );
+	strcpy(ibc->pathsndb, path);
+
+	snprintf(path, sizeof path, "%s/ports/%d/counters/port_rcv_packets",
+						    ibc->ibha, ibc->port);
+	ibc->pathrcvp = malloc( strlen(path)+1 );
+	strcpy(ibc->pathrcvp, path);
+
+	snprintf(path, sizeof path, "%s/ports/%d/counters/port_xmit_packets",
+						    ibc->ibha, ibc->port);
+	ibc->pathsndp = malloc( strlen(path)+1 );
+	strcpy(ibc->pathsndp, path);
 }
 
 /*


### PR DESCRIPTION
Reverts the whitespace changes (original used tab indentation, this had been changed to spaces) and put the code that had been in the `if` below it, where it originally was (instead of above). 